### PR TITLE
Fetch: log http error code

### DIFF
--- a/frontend/src/npm/fetch/src/fetchWithRetries.js
+++ b/frontend/src/npm/fetch/src/fetchWithRetries.js
@@ -73,7 +73,7 @@ export default function fetchWithRetries(
               resolve(response);
             } else if (shouldRetry(requestsAttempted, response.status)) {
               // Fetch was not successful, retrying.
-              retryRequest('HTTP error', uri);
+              retryRequest(`HTTP error ${response.status}`, uri);
             } else {
               // Request was not successful, giving up.
               reject(


### PR DESCRIPTION
When examining app logs, it would be useful to see the http status which caused retrying.