### PR TITLE
Fetch: use different strategy to polyfill 'Object.setPrototypeOf'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,6 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/node": "^7.2.2",
-    "@babel/plugin-transform-object-set-prototype-of-to-assign": "^7.2.0",
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-flow": "^7.0.0",
     "@kiwicom/babel-preset-kiwicom": "^1.0.0",

--- a/frontend/src/npm/babel.config.js
+++ b/frontend/src/npm/babel.config.js
@@ -17,9 +17,6 @@ module.exports = function(api /*: ApiType */) {
     plugins: [
       // TODO: inline require() calls
 
-      // This is necessary to transform 'Object.setPrototypeOf' which is not
-      // supported in React Native environment (Android).
-      '@babel/plugin-transform-object-set-prototype-of-to-assign',
       'babel-plugin-idx',
       '../packages/babel/dev-expression.js',
     ],

--- a/frontend/src/npm/fetch/package.json
+++ b/frontend/src/npm/fetch/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@mrtnzlml/fetch",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "src/fetchWithRetries.js",
   "homepage": "https://github.com/mrtnzlml/quick-payments/tree/master/frontend/src/npm/fetch",
   "dependencies": {

--- a/frontend/src/npm/fetch/src/ResponseError.js
+++ b/frontend/src/npm/fetch/src/ResponseError.js
@@ -1,5 +1,7 @@
 // @flow
 
+import setPrototypeOf from './setPrototypeOf';
+
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
  */
@@ -8,7 +10,7 @@ function ResponseError(response: Object, message?: string) {
   // $FlowExpectedError: ^^
   const instance = new Error(message);
   instance.response = response;
-  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  setPrototypeOf(instance, Object.getPrototypeOf(this));
   if (Error.captureStackTrace) {
     Error.captureStackTrace(instance, ResponseError);
   }
@@ -24,11 +26,6 @@ ResponseError.prototype = Object.create(Error.prototype, {
   },
 });
 
-if (Object.setPrototypeOf) {
-  Object.setPrototypeOf(ResponseError, Error);
-} else {
-  // $FlowExpectedError: mutating this prototype is unsupported (?)
-  ResponseError.__proto__ = Error; // eslint-disable-line no-proto
-}
+setPrototypeOf(ResponseError, Error);
 
 module.exports = ResponseError;

--- a/frontend/src/npm/fetch/src/TimeoutError.js
+++ b/frontend/src/npm/fetch/src/TimeoutError.js
@@ -1,11 +1,13 @@
 // @flow
 
+import setPrototypeOf from './setPrototypeOf';
+
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
  */
 function TimeoutError(message?: string) {
   const instance = new Error(message);
-  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  setPrototypeOf(instance, Object.getPrototypeOf(this));
   if (Error.captureStackTrace) {
     Error.captureStackTrace(instance, TimeoutError);
   }
@@ -21,11 +23,6 @@ TimeoutError.prototype = Object.create(Error.prototype, {
   },
 });
 
-if (Object.setPrototypeOf) {
-  Object.setPrototypeOf(TimeoutError, Error);
-} else {
-  // $FlowExpectedError: mutating this prototype is unsupported (?)
-  TimeoutError.__proto__ = Error; // eslint-disable-line no-proto
-}
+setPrototypeOf(TimeoutError, Error);
 
 module.exports = TimeoutError;

--- a/frontend/src/npm/fetch/src/setPrototypeOf.js
+++ b/frontend/src/npm/fetch/src/setPrototypeOf.js
@@ -1,0 +1,15 @@
+// @flow
+
+/**
+ * Necessary for Android version of React Native which doesn't support 'Object.setPrototypeOf'.
+ *
+ * @see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf#Polyfill
+ */
+export default function setPrototypeOf(obj: Object, prototype: Object) {
+  if (Object.setPrototypeOf) {
+    return Object.setPrototypeOf(obj, prototype);
+  }
+
+  obj.__proto__ = prototype; // eslint-disable-line no-proto
+  return obj;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -660,13 +660,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-object-set-prototype-of-to-assign@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-set-prototype-of-to-assign/-/plugin-transform-object-set-prototype-of-to-assign-7.2.0.tgz#fb1d0bfd1fb8570935304a51cb5ece4a296a2cbf"
-  integrity sha512-EoLB3QrYKP8/LPKPJenbO444tkIWXFIaY09to8+tpqPE86mpavq0zC/t2HoA4phttPzgUpMFvVMJ5gr698zdzw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
 "@babel/plugin-transform-object-super@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz#b35d4c10f56bab5d650047dad0f1d8e8814b6598"


### PR DESCRIPTION
The previous solution was not good enough because 'instanceof' didn't work after the transpilation.

Closes https://github.com/mrtnzlml/quick-payments/issues/44

@tbergq Could you please check if it looks OK?